### PR TITLE
Update gnomadv4_extract_test.py

### DIFF
--- a/gnomad/gnomadv4_extract_test.py
+++ b/gnomad/gnomadv4_extract_test.py
@@ -62,13 +62,17 @@ mt = hl.variant_qc(mt)
 
 # keep only the rows
 # persist to avoid double evaluation later 
-ht = mt.rows().persist()
+#ht = mt.rows().persist()
+
+# remove persist which is suspected to trigger a cryptic error on the dataproc
+ht = mt.rows()
 
 # safe guard, before writting to an Australian bucket. Limit to 1 000 000 variants
 # note that there is no need to write to Australia, since this is an intermediary result
 # it would be preferable to have a bucket hosted in the USA
-if (ht.count() < 1e6) :
+#
+# removed the safe guard after finding the max. size of the rows Table should be aroung 20Gb
+#if (ht.count() < 1e6) :
     # use cpg utils to find proper path (bucket will change with access level)
-    ht.write(output_path('small.ht'), overwrite=True)
-
+ht.write(output_path('small.ht'), overwrite=True)
 


### PR DESCRIPTION
removed the persist() which is suspected to trigger a [cryptic error](https://batch.hail.populationgenomics.org.au/batches/176611/jobs/2)

removed the safe guard after finding out that the maximum size of the rows Hail Table for the full gnomadv4 should be 20Gb